### PR TITLE
Fix node and npm engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "test:ci": "jest --coverage --runInBand"
   },
   "engines": {
-    "node": ">= 6.x <= 9.x",
-    "npm": ">= 2.x <= 5.x",
+    "node": ">= 6.x <= 10.x",
+    "npm": ">= 2.x <= 6.x",
     "yarn": ">=0.27.5 || >=1.0.0-20170811"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "test:ci": "jest --coverage --runInBand"
   },
   "engines": {
-    "node": ">= 6.x <= 10.x",
-    "npm": ">= 2.x <= 6.x",
+    "node": ">= 6",
+    "npm": ">= 2",
     "yarn": ">=0.27.5 || >=1.0.0-20170811"
   },
   "files": [


### PR DESCRIPTION
This PR fixes #1 by adding Node 10 to the list of supported versions (`engines` field in `package.json`). It also adds NPM 6 to prevent warnings when installing with that version.