### PR TITLE
fix bug

### DIFF
--- a/tree.js
+++ b/tree.js
@@ -55,9 +55,11 @@ function print(
   }
 
   // Handle excluded patterns.
-  for (let i = 0; i < options.exclude.length; i++) {
-    if (options.exclude[i].test(path)) {
-      return lines;
+  if(options.exclude && Array.isArray(options.exclude)){
+    for (let i = 0; i < options.exclude.length; i++) {
+      if (options.exclude[i].test(path)) {
+        return lines;
+      }
     }
   }
 


### PR DESCRIPTION
When `options.exclude === undefined` , the program will be crash.
![image](https://user-images.githubusercontent.com/32236122/51736957-66b0ff80-20c6-11e9-84db-712d655037b0.png)

There's something wrong with this line of code.
When `options.exclude === undefined`  and ` DEFAULT_OPTIONS.exclude === [ ] ` , executing this line of code will get the result `combinedOptions.exclude === undefined`

![image](https://user-images.githubusercontent.com/32236122/51737069-a8da4100-20c6-11e9-961b-c8b55ceb1c12.png)


To this end, I wrote a little demo, as follows:
![image](https://user-images.githubusercontent.com/32236122/51737372-606f5300-20c7-11e9-8583-c5d6f98a0b04.png)

So, I added exception handling to where the program crashed. 

Now it can run correctly.😄 