### PR TITLE
`-S`, `--line-ascii` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ $ tree -h
     -L, --max-depth <n>       Max display depth of the directory tree.
     -r, --reverse             Sort the output in reverse alphabetic order.
     -F, --trailing-slash      Append a '/' for directories.
+    -S, --line-ascii          Turn on ASCII line graphics.
     -h, --help                output usage information
 ```
 
@@ -80,6 +81,7 @@ const string = tree('path/to/dir', options);
 | `maxDepth`      | `Number.POSITIVE_INFINITY` | Number  | Max display depth of the directory tree.                                                                                              |
 | `reverse`       | `false`                    | Boolean | Sort the output in reverse alphabetic order.                                                                                          |
 | `trailingSlash` | `false`                    | Boolean | Appends a trailing slash behind directories.                                                                                          |
+| `lineAscii`     | `false`                    | Boolean | Turn on ASCII line graphics.                                                                                                          |
 
 ```js
 const string = tree('path/to/dir', {

--- a/bin/tree.js
+++ b/bin/tree.js
@@ -25,7 +25,8 @@ program
     parseInt,
   )
   .option('-r, --reverse', 'Sort the output in reverse alphabetic order.')
-  .option('-F, --trailing-slash', "Append a '/' for directories.");
+  .option('-F, --trailing-slash', "Append a '/' for directories.")
+  .option('-S, --line-ascii', "Turn on ASCII line graphics.");
 
 program.parse(process.argv);
 const path = program.args[0] || '.'; // Defaults to CWD if not specified.
@@ -38,6 +39,7 @@ const options = {
   maxDepth: program.maxDepth,
   reverse: program.reverse,
   trailingSlash: program.trailingSlash,
+  ascii: program.lineAscii
 };
 
 Object.keys(options).forEach((key) => {

--- a/tree.js
+++ b/tree.js
@@ -11,14 +11,23 @@ const DEFAULT_OPTIONS = {
   maxDepth: Number.POSITIVE_INFINITY,
   reverse: false,
   trailingSlash: false,
+  ascii: false,
 };
 
-const SYMBOLS = {
+const SYMBOLS_ANSI = {
   BRANCH: '├── ',
   EMPTY: '',
   INDENT: '    ',
   LAST_BRANCH: '└── ',
   VERTICAL: '│   ',
+};
+
+const SYMBOLS_ASCII = {
+  BRANCH: '|-- ',
+  EMPTY: '',
+  INDENT: '    ',
+  LAST_BRANCH: '`-- ',
+  VERTICAL: '|   ',
 };
 
 const EXCLUDED_PATTERNS = [/\.DS_Store/];
@@ -41,6 +50,8 @@ function print(
   const isFile = !isDir;
 
   const lines = [];
+
+  const SYMBOLS = options.ascii ? SYMBOLS_ASCII : SYMBOLS_ANSI;
 
   // Do not show these regardless.
   for (let i = 0; i < EXCLUDED_PATTERNS.length; i++) {


### PR DESCRIPTION
Add `-S` option to output tree graph line in ascii chars.

```
% bin/tree.js -S | head -n10
tree-node-cli
|-- bin
|   `-- tree.js
|-- jest.config.js
|-- LICENSE
|-- node_modules
|   |-- @babel
|   |   |-- code-frame
|   |   |   |-- lib
|   |   |   |   `-- index.js
```

The option name `-S` is following the Linux `tree` command
(Linux-`tree` uses the option name `-A` for ANSI line graphics, or double-byte line chars).
