### PR TITLE
Fix: Align/Match Option Key Names with Documentation for `lineAscii`

### DIFF
--- a/src/__tests__/__snapshots__/tree.test.js.snap
+++ b/src/__tests__/__snapshots__/tree.test.js.snap
@@ -358,6 +358,124 @@ exports[`tree exclude 21`] = `
 ├── alpha.txt"
 `;
 
+exports[`tree lineAscii 1`] = `
+"chain
+\`-- alpha
+    \`-- alpha
+        \`-- alpha
+            \`-- alpha
+                \`-- alpha
+                    \`-- alpha
+                        \`-- alpha
+                            \`-- alpha
+                                \`-- alpha.txt"
+`;
+
+exports[`tree lineAscii 2`] = `
+"double-level
+|-- alpha.txt
+\`-- beta
+    \`-- alpha.txt"
+`;
+
+exports[`tree lineAscii 3`] = `"empty-dir"`;
+
+exports[`tree lineAscii 4`] = `
+"multi-files
+|-- alpha.txt
+|-- beta.txt
+\`-- charlie.txt"
+`;
+
+exports[`tree lineAscii 5`] = `
+"multi-level
+|-- alpha.txt
+|-- beta
+|   |-- alpha
+|   |   |-- alpha.txt
+|   |   \`-- beta
+|   |       \`-- alpha.txt
+|   |-- beta.txt
+|   \`-- charlie
+|       \`-- alpha.txt
+|-- charlie
+|   |-- alpha.txt
+|   |-- beta
+|   |   \`-- alpha.txt
+|   \`-- charlie.txt
+\`-- delta.txt"
+`;
+
+exports[`tree lineAscii 6`] = `
+"single-file
+\`-- alpha.txt"
+`;
+
+exports[`tree lineAscii 7`] = `
+"single-level
+|-- alpha.txt
+\`-- beta"
+`;
+
+exports[`tree lineAscii 8`] = `
+"chain
+└── alpha
+    └── alpha
+        └── alpha
+            └── alpha
+                └── alpha
+                    └── alpha
+                        └── alpha
+                            └── alpha
+                                └── alpha.txt"
+`;
+
+exports[`tree lineAscii 9`] = `
+"double-level
+├── alpha.txt
+└── beta
+    └── alpha.txt"
+`;
+
+exports[`tree lineAscii 10`] = `"empty-dir"`;
+
+exports[`tree lineAscii 11`] = `
+"multi-files
+├── alpha.txt
+├── beta.txt
+└── charlie.txt"
+`;
+
+exports[`tree lineAscii 12`] = `
+"multi-level
+├── alpha.txt
+├── beta
+│   ├── alpha
+│   │   ├── alpha.txt
+│   │   └── beta
+│   │       └── alpha.txt
+│   ├── beta.txt
+│   └── charlie
+│       └── alpha.txt
+├── charlie
+│   ├── alpha.txt
+│   ├── beta
+│   │   └── alpha.txt
+│   └── charlie.txt
+└── delta.txt"
+`;
+
+exports[`tree lineAscii 13`] = `
+"single-file
+└── alpha.txt"
+`;
+
+exports[`tree lineAscii 14`] = `
+"single-level
+├── alpha.txt
+└── beta"
+`;
+
 exports[`tree maxDepth 1`] = `
 "chain
 └── alpha"

--- a/src/__tests__/tree.test.js
+++ b/src/__tests__/tree.test.js
@@ -113,4 +113,20 @@ describe('tree', () => {
       ).toMatchSnapshot();
     });
   });
+
+  test('lineAscii', () => {
+    dirs.forEach((dir) => {
+      const result = tree(path.join(PATH_TO_TEST, dir), {
+        lineAscii: true,
+      });
+      expect(result).toMatchSnapshot();
+    });
+    dirs.forEach((dir) => {
+      const result = tree(path.join(PATH_TO_TEST, dir), {
+        lineAscii: false,
+      });
+      expect(result).toMatchSnapshot();
+    });
+  });
+  
 });

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const DEFAULT_OPTIONS = {
   maxDepth: Number.POSITIVE_INFINITY,
   reverse: false,
   trailingSlash: false,
-  ascii: false,
+  lineAscii: false,
 };
 
 const SYMBOLS_ANSI = {
@@ -54,7 +54,7 @@ function print(
 
   const lines = [];
 
-  const SYMBOLS = options.ascii ? SYMBOLS_ASCII : SYMBOLS_ANSI;
+  const SYMBOLS = options.lineAscii ? SYMBOLS_ASCII : SYMBOLS_ANSI;
 
   // Do not show these regardless.
   for (let i = 0; i < EXCLUDED_PATTERNS.length; i++) {


### PR DESCRIPTION
## Fix: Align/Match Option Key Names with Documentation for `lineAscii`

### Summary

This PR addresses an inconsistency between the code and the documented API/CLI options for the `lineAscii` feature in `tree-node-cli`. Initially, I considered updating the documentation to match the internal logic. However, I noticed that the CLI API already used the `line-ascii` naming convention. To maintain consistency across the CLI and Node.js API, I corrected the implementation instead. Previously, the code used the incorrect key name `ascii`, causing unexpected behavior when using the Node.js API and the README documentation.

### Changes

1. **Bug Fix:**
   - Replaced all references to the incorrect key `ascii` with the correct key `lineAscii` in `src/index.js`.

2. **Testing Enhancements:**
   - Added dedicated test cases for the `lineAscii` feature to validate its functionality for both `true` and `false` values.
   - Regenerated snapshots to reflect the changes for the corrected key.

3. **Documentation Alignment:**
   - Ensured the implementation now fully adheres to the documented API and CLI options, maintaining consistency across all interfaces.

### Testing

- Verified that the `lineAscii` option works as intended and matches the documentation.
- Confirmed all existing tests pass with the updated implementation.
- Added new test cases to provide full coverage for the `lineAscii` option.

```bash
% npm run test

> tree-node-cli@1.6.0 test
> jest --coverage

 PASS  src/__tests__/tree.test.js
  tree
    ✓ default (3 ms)
    ✓ allFiles (1 ms)
    ✓ dirsFirst (1 ms)
    ✓ sizes (152 ms)
    ✓ dirsOnly (1 ms)
    ✓ exclude (2 ms)
    ✓ maxDepth (2 ms)
    ✓ reverse (1 ms)
    ✓ trailingSlash (1 ms)
    ✓ lineAscii (2 ms)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |   96.83 |    94.74 |     100 |   96.67 |                   
 index.js |   96.83 |    94.74 |     100 |   96.67 | 62,68             
----------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   98 passed, 98 total
Time:        0.959 s
Ran all test suites.
```

### Checklist

- [x] Corrected the option key mismatch (`ascii` -> `lineAscii`).
- [x] Verified alignment with the documented API/CLI behavior.
- [x] Regenerated snapshots for updated test cases.
